### PR TITLE
Fixes Endless Loop of ListUsersPaginator

### DIFF
--- a/user.go
+++ b/user.go
@@ -190,7 +190,7 @@ type ListUsersPaginator struct {
 
 func NewListUsersPaginator(client ListUsersPaginatorClient, params *ListUsersInput) *ListUsersPaginator {
 	if params == nil {
-		params = &ListUsersInput{}
+		params = &ListUsersInput{Limit: 20}
 	}
 
 	return &ListUsersPaginator{


### PR DESCRIPTION
When the ListUsersPaginator is created without ListUsersInput, then a
default input is created. This input has been missing a Limit, which
means that the default int value of 0 has been used.

This caused the code in the HasMorePages function to always return
true, causing the endless loop.

The fix for this issue is to set the Limit to 10 if no input has been
provided.

Closes #29