### PR TITLE
Remove closeCloser Function

### DIFF
--- a/bonus.go
+++ b/bonus.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strings"
 )
@@ -59,9 +58,8 @@ func (c *Client) CreateBonus(ctx context.Context, params *CreateBonusInput) (*Cr
 	if err != nil {
 		return nil, err
 	}
-	defer closeCloser(resp.Body)
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := readAndCloseBody(resp)
 	if err != nil {
 		return nil, err
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,72 @@
+package bonusly
+
+import (
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type errReadCloser struct {
+	rerr error
+	cerr error
+}
+
+func (r errReadCloser) Read(p []byte) (n int, err error) {
+	return 0, r.rerr
+}
+
+func (r errReadCloser) Close() error {
+	return r.cerr
+}
+
+func Test_readAndCloseBody(t *testing.T) {
+	type args struct {
+		r *http.Response
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []byte
+		wantErr bool
+	}{
+		{
+			"nil-response",
+			args{r: nil},
+			nil,
+			true,
+		},
+		{
+			"ok",
+			args{r: &http.Response{Body: ioutil.NopCloser(strings.NewReader("Test"))}},
+			[]byte("Test"),
+			false,
+		},
+		{
+			"error-read",
+			args{r: &http.Response{Body: errReadCloser{rerr: errors.New("read error")}}},
+			nil,
+			true,
+		},
+		{
+			"error-read-close",
+			args{r: &http.Response{Body: errReadCloser{rerr: errors.New("read error"), cerr: errors.New("close error")}}},
+			nil,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := readAndCloseBody(tt.args.r)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("readAndCloseBody() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("readAndCloseBody() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/redemptions.go
+++ b/redemptions.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -103,9 +102,8 @@ func (c *Client) ListRedemptions(ctx context.Context, params *ListRedemptionsInp
 	if err != nil {
 		return nil, err
 	}
-	defer closeCloser(resp.Body)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := readAndCloseBody(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -173,9 +171,8 @@ func (c *Client) GetRedemption(ctx context.Context, params *GetRedemptionInput) 
 	if err != nil {
 		return nil, err
 	}
-	defer closeCloser(resp.Body)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := readAndCloseBody(resp)
 	if err != nil {
 		return nil, err
 	}

--- a/rewards.go
+++ b/rewards.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 )
@@ -111,9 +110,8 @@ func (c *Client) ListRewards(ctx context.Context, params *ListRewardsInput) (*Li
 	if err != nil {
 		return nil, err
 	}
-	defer closeCloser(resp.Body)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := readAndCloseBody(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -266,9 +264,8 @@ func (c *Client) GetReward(ctx context.Context, params *GetRewardInput) (*GetRew
 	if err != nil {
 		return nil, err
 	}
-	defer closeCloser(resp.Body)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := readAndCloseBody(resp)
 	if err != nil {
 		return nil, err
 	}

--- a/user.go
+++ b/user.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -239,9 +238,8 @@ func (c *Client) ListUsers(ctx context.Context, params *ListUsersInput) (*ListUs
 	if err != nil {
 		return nil, err
 	}
-	defer closeCloser(resp.Body)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := readAndCloseBody(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -356,9 +354,8 @@ func (c *Client) GetUser(ctx context.Context, params *GetUserInput) (*GetUserOut
 	if err != nil {
 		return nil, err
 	}
-	defer closeCloser(resp.Body)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := readAndCloseBody(resp)
 	if err != nil {
 		return nil, err
 	}

--- a/webhooks.go
+++ b/webhooks.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 )
@@ -76,9 +75,8 @@ func (c *Client) ListWebhooks(ctx context.Context) (*ListWebhooksOutput, error) 
 	if err != nil {
 		return nil, err
 	}
-	defer closeCloser(resp.Body)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := readAndCloseBody(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -145,9 +143,8 @@ func (c *Client) CreateWebhook(ctx context.Context, params *CreateWebhookInput) 
 	if err != nil {
 		return nil, err
 	}
-	defer closeCloser(resp.Body)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := readAndCloseBody(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -229,9 +226,8 @@ func (c *Client) UpdateWebhook(ctx context.Context, params *UpdateWebhookInput) 
 	if err != nil {
 		return nil, err
 	}
-	defer closeCloser(resp.Body)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := readAndCloseBody(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -285,9 +281,8 @@ func (c *Client) DeleteWebhook(ctx context.Context, params *DeleteWebhookInput) 
 	if err != nil {
 		return nil, err
 	}
-	defer closeCloser(resp.Body)
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := readAndCloseBody(resp)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The function was a left over of the initial code. It closed io.ReadCloser
but did throw a "panic" if closer.Close() caused an error. SDK should not
panic and therefore, the function needed to be refactored.

The current solution could be better, but I opted for a "simple" solution
without using defer with an anonymous function and named return values
like the AWS SDK. This would probably be the "better" solution but is
also harder to read for newcomers.